### PR TITLE
Update ExpenseItHomeViewModel.fs

### DIFF
--- a/VisualStudio/FSharpWpfMvvmTemplate/src/App/ViewModel/ExpenseItHomeViewModel.fs
+++ b/VisualStudio/FSharpWpfMvvmTemplate/src/App/ViewModel/ExpenseItHomeViewModel.fs
@@ -27,7 +27,7 @@ type ExpenseItHomeViewModel(expenseReportRepository : ExpenseReportRepository) =
         | ApprovalStatus.Rejected ->
             this.LastApprovalDisplayMessage <- sprintf "Expense report rejected for %s" name
     new () = ExpenseItHomeViewModel(ExpenseReportRepository())
-    member x.ExpenseReports = 
+    member val ExpenseReports = 
         new ObservableCollection<ExpenseReport>(
             expenseReportRepository.GetAll())
     member x.SelectedExpenseReport 


### PR DESCRIPTION
this syntax is causing it to recreate the observable collection on every pass, there is no backing field created.  see http://stackoverflow.com/a/3913701/57883
